### PR TITLE
Moved enableTransmit into switchService to allow different acc to use different pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ really help with.
   the code, defaults to 10 (as per [the original rcswitch
   code](https://github.com/sui77/rc-switch/blob/a7333b87d7e3ef8d9ce2eb6ca44843a8d19e7393/RCSwitch.cpp#L103))
 
+# FAQ / Troubleshooting
+
+It seems that the `gpiomem` system I use and the SysFS method of interacting with the GPIO are not compatible for reasons [explained in this issue](https://github.com/n8henrie/homebridge-rcswitch-gpiomem/issues/11). Make sure that you aren't also using programs that access the GPIO by way of SysFS or this library may not work.
+
 # Changelog
 
 ## 20160727 :: 1.1.3

--- a/index.js
+++ b/index.js
@@ -38,8 +38,6 @@ function RadioSwitch(log, config) {
                 "doesn't appear to include at least one of these pairs.");
     }
 
-    rcswitch.enableTransmit(config.pin || 17);
-
     var informationService = new Service.AccessoryInformation();
 
     informationService
@@ -55,6 +53,7 @@ function RadioSwitch(log, config) {
         .getCharacteristic(Characteristic.On)
         .on('set', function(value, callback) {
             state = value;
+    		rcswitch.enableTransmit(config.pin || 17);
             rcswitch.setPulseLength(config.pulseLength || 190);
             rcswitch.setRepeatTransmit(config.repeats || 10);
             if (state) {


### PR DESCRIPTION
Had trouble having multiple rc accessories that used different transmitters on different gpio pins. Moving enableTransmit into switchService allows both 315MHz and 433MHz switches to work simultaneously.